### PR TITLE
Emit close + set closed if ready fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,14 @@ module.exports = class ReadyResource extends EventEmitter {
 }
 
 async function open (self) {
-  await self._open()
+  try {
+    await self._open()
+  } catch (err) {
+    self.closing = Promise.resolve()
+    self.closed = true
+    self.emit('close')
+    throw err
+  }
   self.opened = true
   self.emit('ready')
 }

--- a/test.js
+++ b/test.js
@@ -25,3 +25,18 @@ test('basic', async function (t) {
   t.is(opened, true)
   t.is(closed, true)
 })
+
+test('ready rejecting emits close', async t => {
+  t.plan(4)
+
+  const r = new Resource()
+  r._open = () => Promise.reject(new Error('bad open'))
+
+  r.on('close', () => {
+    t.pass('emitted close')
+    t.ok(r.closed)
+    t.ok(r.closing)
+  })
+
+  await t.exception(r.ready())
+})


### PR DESCRIPTION
If `ready` fails, it's nicer if `ReadyResource` emits `close` and sets `closed` + `closing`, so that flows like the following work:

```js
const r = new MyResource()
r.on('close', () => uncache(r))
cache(r)
```